### PR TITLE
change custom error scope

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -82,8 +82,8 @@ func (p *Backoff) advance() time.Duration {
 }
 
 var (
-	errLimitReached = errors.New("retry limit reached")
-	errExpired      = errors.New("operation is expired")
+	ErrLimitReached = errors.New("retry limit reached")
+	ErrExpired      = errors.New("operation is expired")
 )
 
 func (p *Backoff) age() time.Duration {
@@ -95,7 +95,7 @@ func (p *Backoff) age() time.Duration {
 func (p *Backoff) Advance() (time.Duration, error) {
 	p.Start()
 	if p.Limit > 0 && p.n >= p.Limit {
-		return 0, errLimitReached
+		return 0, ErrLimitReached
 	}
 	d := p.advance()
 	if p.Peak > 0 && d > p.Peak {
@@ -103,7 +103,7 @@ func (p *Backoff) Advance() (time.Duration, error) {
 	}
 	age := p.age() + d
 	if p.MaxAge > 0 && age >= p.MaxAge {
-		return 0, errExpired
+		return 0, ErrExpired
 	}
 	return d, nil
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -138,7 +138,7 @@ func TestAdvanceMaxAge(t *testing.T) {
 			return
 		}
 	}
-	t.Errorf("Age = %v, MaxAge = %v; want %v", w.age(), w.MaxAge, errExpired)
+	t.Errorf("Age = %v, MaxAge = %v; want %v", w.age(), w.MaxAge, ErrExpired)
 }
 
 func TestStartMaxAge(t *testing.T) {
@@ -154,7 +154,7 @@ func TestStartMaxAge(t *testing.T) {
 			return
 		}
 	}
-	t.Errorf("Age = %v, MaxAge = %v; want %v", w.age(), w.MaxAge, errExpired)
+	t.Errorf("Age = %v, MaxAge = %v; want %v", w.age(), w.MaxAge, ErrExpired)
 }
 
 func Example() {


### PR DESCRIPTION
I want to return the original response as it is depending on the backoff error type.
How about exposing CustomError?

```go
	resp, err := http.Get("http://example.com")
	// ... retry logic

	if err := w.Wait(ctx); err != nil {
		if errors.Is(err, backoff.ErrLimitReached) {
			return resp, err   // hope original response
		} else {
			return nil, err   // hope backoff limitation
		}
	}
```